### PR TITLE
Change color of tracking-change under source control

### DIFF
--- a/src/StarrySky/StarrySky.vstheme
+++ b/src/StarrySky/StarrySky.vstheme
@@ -5769,15 +5769,15 @@
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
       <Color Name="Track additions in documents under source control">
-        <Background Type="CT_RAW" Source="FF55B155" />
+        <Background Type="CT_RAW" Source="FF3BFF95" />
         <Foreground Type="CT_AUTOMATIC" Source="FF1E1E1E" />
       </Color>
       <Color Name="Track modifications in documents under source control">
-        <Background Type="CT_RAW" Source="FF3595DE" />
+        <Background Type="CT_RAW" Source="FFFF8C00" />
         <Foreground Type="CT_AUTOMATIC" Source="FF1E1E1E" />
       </Color>
       <Color Name="Track deletions in documents under source control">
-        <Background Type="CT_RAW" Source="FFFF6666" />
+        <Background Type="CT_RAW" Source="FFFF5DCC" />
         <Foreground Type="CT_AUTOMATIC" Source="FF1E1E1E" />
       </Color>
       <Color Name="mergeEditor.AcceptedLine">


### PR DESCRIPTION
This patch changes the following color of tracking-change under source control.
  - addition
  - modification
  - deletion

Fix #19 