### PR TITLE
Fix color of selected line number.

### DIFF
--- a/src/StarrySky/StarrySky.vstheme
+++ b/src/StarrySky/StarrySky.vstheme
@@ -6619,7 +6619,7 @@
       </Color>
       <Color Name="Selected Line Number">
         <Background Type="CT_INVALID" Source="00000000" />
-        <Foreground Type="CT_RAW" Source="FF000000" />
+        <Foreground Type="CT_RAW" Source="FFBF52FF" />
       </Color>
       <Color Name="StickyScrollLineHighlightFormat">
         <Background Type="CT_INVALID" Source="00000000" />


### PR DESCRIPTION
This patch fixes colors of selected line number because it's hard to read.
(Fix #60)