### PR TITLE
Change brace matching color

### DIFF
--- a/src/StarrySky/StarrySky.vstheme
+++ b/src/StarrySky/StarrySky.vstheme
@@ -5338,7 +5338,7 @@
         <Foreground Type="CT_RAW" Source="FF3BFF95" />
       </Color>
       <Color Name="brace matching">
-        <Background Type="CT_RAW" Source="FF1AFE49" />
+        <Background Type="CT_RAW" Source="FF48830E" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
       <Color Name="OverviewMarginCaret">


### PR DESCRIPTION
This patch changes brace matching color from 1AFE49 to 48830E, because 1AFE49 is a bit vivid.
(Fix #61)