### PR TITLE
ci: Change autolabeler config from feature to enhancement

### DIFF
--- a/.github/release-drafter.yaml
+++ b/.github/release-drafter.yaml
@@ -1,9 +1,9 @@
 name-template: 'v$RESOLVED_VERSION 🌈'
 tag-template: 'v$RESOLVED_VERSION'
 categories:
-  - title: '🚀 Features'
+  - title: '🚀 Enhancement'
     labels:
-      - 'feature'
+      - 'enhancement'
   - title: '🐛 Bug Fixes'
     labels:
       - 'bug'
@@ -37,7 +37,7 @@ template: |
   $CHANGES
 
 autolabeler:
-  - label: 'feature'
+  - label: 'enhancement'
     branch:
       - '/^feature[/-].+/'
   - label: 'bug'


### PR DESCRIPTION
This patch changes autolabeler configuration to use enhancement label
instead of feature label in release-drafter.yaml.

Signed-off-by: Taku Izumi <admin@orz-style.com>