### PR TITLE
ci: Fix trigger branchname in GitHub Actions Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - "main"
+      - "master"
 
 env:
   BUILD_VERSION: ""

--- a/.github/workflows/release-drafter-wf.yaml
+++ b/.github/workflows/release-drafter-wf.yaml
@@ -2,7 +2,9 @@ name: Release Drafter
 
 on:
   push:
-    branches: [main]
+    branches:
+      - "main"
+      - "master"
   # pull_request event is required only for autolabeler
   pull_request:
     # Only following types are handled by the action, but one can default to all as well


### PR DESCRIPTION
This repository uses traditional "master" brach instead of "main" branch.
In order to trigger workflow properly, this patch adds "master" branch name
support in each workflow file.

Signed-off-by: Taku Izumi <admin@orz-style.com>