### PR TITLE
Fix the color of file preview tab when inactive

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,4 +63,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: "StarrySky-${{ env.BUILD_VERSION }}.${{ github.run_number }}"
-          path: ./src/StarrySky/bin/Release/StarrySky.pkgdef
+          path: ./src/StarrySky/bin/Release/StarrySky.vsix

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Zip artifacts
         run: |
           $artifact = "StarrySky-$($env:BUILD_VERSION)_bin.zip"
-          Compress-Archive ./src/StarrySky/bin/Release/StarrySky.pkgdef $artifact
+          Compress-Archive ./src/StarrySky/bin/Release/StarrySky.vsix $artifact
 
       # Upload release Assets
       # https://github.com/AButler/upload-release-assets

--- a/src/StarrySky/StarrySky.vstheme
+++ b/src/StarrySky/StarrySky.vstheme
@@ -2558,7 +2558,7 @@
         <Background Type="CT_RAW" Source="FF14102C" />
       </Color>
       <Color Name="FileTabProvisionalInactiveForeground">
-        <Background Type="CT_RAW" Source="FF14102C" />
+        <Background Type="CT_RAW" Source="FF857EA0" />
       </Color>
       <Color Name="FileTabProvisionalSelectedInactive">
         <Background Type="CT_RAW" Source="FF14102C" />
@@ -3385,10 +3385,10 @@
         <Background Type="CT_RAW" Source="FF1AFE49" />
       </Color>
       <Color Name="FileTabProvisionalInactive">
-        <Background Type="CT_RAW" Source="FF2D2D30" />
+        <Background Type="CT_RAW" Source="FF2C214F" />
       </Color>
       <Color Name="FileTabProvisionalInactiveBorder">
-        <Background Type="CT_RAW" Source="FF2D2D30" />
+        <Background Type="CT_RAW" Source="FF2C214F" />
       </Color>
       <Color Name="FileTabProvisionalSelectedActiveBorder">
         <Background Type="CT_RAW" Source="FF68217A" />


### PR DESCRIPTION
This patch fixes the color of file preview tab when inactive,
because it's hard to see due to bad contrast.

(Fix #73)

Signed-off-by: Taku Izumi <admin@orz-style.com>