### PR TITLE
ci: Fix the file to be picked up in build.yaml and release.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,4 +63,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: "StarrySky-${{ env.BUILD_VERSION }}.${{ github.run_number }}"
-          path: ./src/StarrySky/bin/Release/StarrySky.pkgdef
+          path: ./src/StarrySky/bin/Release/StarrySky.vsix

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Zip artifacts
         run: |
           $artifact = "StarrySky-$($env:BUILD_VERSION)_bin.zip"
-          Compress-Archive ./src/StarrySky/bin/Release/StarrySky.pkgdef $artifact
+          Compress-Archive ./src/StarrySky/bin/Release/StarrySky.vsix $artifact
 
       # Upload release Assets
       # https://github.com/AButler/upload-release-assets


### PR DESCRIPTION
There's bug in build.yaml and release.yaml workflow files.
Main exension file is not *.pkgdef but *.vsix.
This patch fixes the vsix file to be picked up.

Signed-off-by: Taku Izumi <admin@orz-style.com>