### PR TITLE
Update VsixColorCompiler Nuget package

### DIFF
--- a/src/StarrySky/StarrySky.csproj
+++ b/src/StarrySky/StarrySky.csproj
@@ -56,7 +56,7 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.VsixColorCompiler" Version="17.0.31709.430" />
+    <PackageReference Include="Microsoft.VisualStudio.VsixColorCompiler" Version="17.11.35325.10" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="LICENSE.txt">


### PR DESCRIPTION
This patch updates VsixColorCompiler Nuget package to version 17.5.33428.366

Signed-off-by: Taku Izumi <admin@orz-style.com>