### PR TITLE
Improve transparency of QuickFix dropdown menu

### DIFF
--- a/src/StarrySky/StarrySky.vstheme
+++ b/src/StarrySky/StarrySky.vstheme
@@ -2702,10 +2702,10 @@
         <Background Type="CT_RAW" Source="80C5C5C5" />
       </Color>
       <Color Name="CommandBarMenuBackgroundGradientBegin">
-        <Background Type="CT_RAW" Source="A006320E" />
+        <Background Type="CT_RAW" Source="E006320E" />
       </Color>
       <Color Name="CommandBarMenuBackgroundGradientEnd">
-        <Background Type="CT_RAW" Source="A006320E" />
+        <Background Type="CT_RAW" Source="E006320E" />
       </Color>
       <Color Name="CommandBarMenuIconBackground">
         <Background Type="CT_RAW" Source="A006320E" />


### PR DESCRIPTION
Currently the transparency of QuickFix dropdown menu is a bit high.
Therefore it's sometimes difficult to read the menu text.
This patch changes the transparency of QuickFix dropdown menu

Signed-off-by: Taku Izumi <admin@orz-style.com>