### PR TITLE
Change the colors of Document Tab, indicator margin

### DIFF
--- a/src/StarrySky/StarrySky.vstheme
+++ b/src/StarrySky/StarrySky.vstheme
@@ -2063,7 +2063,7 @@
         <Background Type="CT_RAW" Source="FF2C214F" />
       </Color>
       <Color Name="FileTabActiveGroupBackground">
-        <Background Type="CT_RAW" Source="FF2C214F" />
+        <Background Type="CT_RAW" Source="FF271C4A" />
       </Color>
       <Color Name="ControlLinkTextHover">
         <Background Type="CT_RAW" Source="FFFFFFFF" />
@@ -2401,7 +2401,7 @@
         <Background Type="CT_RAW" Source="FF721BF2" />
       </Color>
       <Color Name="FileTabBackground">
-        <Background Type="CT_RAW" Source="FF2C214F" />
+        <Background Type="CT_RAW" Source="FF271C4A" />
       </Color>
       <Color Name="FileTabButtonDownInactiveGlyph">
         <Background Type="CT_RAW" Source="FF2C214F" />
@@ -7879,7 +7879,7 @@
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
       <Color Name="Indicator Margin">
-        <Background Type="CT_RAW" Source="FF14102C" />
+        <Background Type="CT_RAW" Source="FF372963" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
       <Color Name="Plain Text">


### PR DESCRIPTION
This patch changes Document Tab background color and Indicator Margin
background color to stand out.
(Fix #85)

Signed-off-by: Taku Izumi <admin@orz-style.com>