### PR TITLE
Fix border color of Json schema selection dropdown on mouseover

### DIFF
--- a/src/StarrySky/StarrySky.vstheme
+++ b/src/StarrySky/StarrySky.vstheme
@@ -1969,7 +1969,7 @@
         <Background Type="CT_RAW" Source="FF06320E" />
       </Color>
       <Color Name="ComboBoxMouseOverBorder">
-        <Background Type="CT_RAW" Source="FF14102C" />
+        <Background Type="CT_RAW" Source="FF45425C" />
       </Color>
       <Color Name="CommandBarSplitButtonSeparator">
         <Background Type="CT_RAW" Source="FF007F00" />


### PR DESCRIPTION
Commit 6ebc0c8 causes level down.
There's no border of Json schema selection dropdown on mouseover.
This patch fixes this problem.
(FIx #91)

Signed-off-by: Taku Izumi <admin@orz-style.com>