### PR TITLE
Visual Studio 2022 arm64 support

### DIFF
--- a/src/StarrySky/source.extension.vsixmanifest
+++ b/src/StarrySky/source.extension.vsixmanifest
@@ -13,6 +13,9 @@
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+            <ProductArchitecture>arm64</ProductArchitecture>
+        </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
Currently this theme supports  Visual Studio 2022  x86_64 only.
This patch adds configuration for arm64 build to support arm64
verson of  Visual Studio 2022. 
(Fix #97)

Signed-off-by: Taku Izumi <admin@orz-style.com>