### PR TITLE
ci: Add version check step to Release GitHub Actions Workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,7 @@ on:
 
 env:
   BUILD_VERSION: ""
+  TAG_VERSION: ${{ github.ref_name }}
 
 jobs:
   release:
@@ -35,6 +36,18 @@ jobs:
           $version = $manifest.PackageManifest.Metadata.Identity.Version
           Write-Output $version
           Write-Output "BUILD_VERSION=$version" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+
+      # Version Check
+      - name: Version Check
+        run: |
+          $build_version = "v" + $($env:BUILD_VERSION)
+          Write-Output "Build Version = $build_version"
+          $tag_version = $($env:TAG_VERSION)
+          Write-Output "GitTag Version = $tag_version"
+          if (-Not($build_version -eq $tag_version)) {
+            Write-Output "Version Mismatch!"
+            exit 1
+          }
 
       # Restore Apps
       - name: Restore the app


### PR DESCRIPTION
This patch adds "Version Check" step to release job in Release GitHub Actions
Workflow in order to abort release-build if git tag version is not the same as
the source code version.

Signed-off-by: Taku Izumi <admin@orz-style.com>