### PR TITLE
Fix ListItemPressed color in StartWindow

### DIFF
--- a/src/StarrySky/StarrySky.vstheme
+++ b/src/StarrySky/StarrySky.vstheme
@@ -7038,7 +7038,7 @@
       </Color>
       <Color Name="StartPageListItemPressed">
         <Background Type="CT_RAW" Source="FF14102C" />
-        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+        <Foreground Type="CT_RAW" Source="FF1AFE49" />
       </Color>
       <Color Name="StartPageNotificationDotBorder">
         <Foreground Type="CT_RAW" Source="FF14102C" />


### PR DESCRIPTION
This patch fixes ListItemPressed color in StartWindow. (Fix #102)

Signed-off-by: Taku Izumi <admin@orz-style.com>