### PR TITLE
Fix separator color in Call Hierarchy window

### DIFF
--- a/src/StarrySky/StarrySky.vstheme
+++ b/src/StarrySky/StarrySky.vstheme
@@ -2749,7 +2749,7 @@
         <Background Type="CT_RAW" Source="FF1AFE49" />
       </Color>
       <Color Name="CommandBarMenuSeparator">
-        <Background Type="CT_RAW" Source="FFBBBBBB" />
+        <Background Type="CT_RAW" Source="FF47445D" />
       </Color>
       <Color Name="CommandBarHover">
         <Background Type="CT_RAW" Source="FF45425C" />


### PR DESCRIPTION
This patch fixes separator color in Call Hierarchy window,
because it is a bit vivid. (Fix #103)

Signed-off-by: Taku Izumi <admin@orz-style.com>