### PR TITLE
Fix ComboBoxListItemBackgroundHover color

### DIFF
--- a/src/StarrySky/StarrySky.vstheme
+++ b/src/StarrySky/StarrySky.vstheme
@@ -1166,7 +1166,7 @@
         <Background Type="CT_RAW" Source="FF1AFE49" />
       </Color>
       <Color Name="ComboBoxListItemBackgroundHover">
-        <Background Type="CT_RAW" Source="FF14102C" />
+        <Background Type="CT_RAW" Source="8014102C" />
       </Color>
       <Color Name="ComboBoxListItemBorderHover">
         <Background Type="CT_RAW" Source="FF14102C" />


### PR DESCRIPTION
This patch fixes ComboBoxListItemBackgroundHover color
to make it consistent.  (Fix #116)

Signed-off-by: Taku Izumi <admin@orz-style.com>