### PR TITLE
ci: Use VsixPublisherAction in release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -99,6 +99,7 @@ jobs:
           mkdir -p ./artifacts
           Copy-Item -Path './src/StarrySky/bin/Release/StarrySky.vsix' -Destination './artifacts/'
           Copy-Item -Path './src/StarrySky/publishManifest.json' -Destination './artifacts/'
+          Copy-Item -Path './src/StarrySky/overview.md' -Destination './artifacts/'
 
       # Set up artifact name
       - name: Set artifact name
@@ -116,3 +117,4 @@ jobs:
           path: |
               ./artifacts/StarrySky.vsix
               ./artifacts/publishManifest.json
+              ./artifacts/overview.md

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,12 +30,12 @@ jobs:
       - name: Set Release file name
         run: |
           VERSION=$(echo ${{ inputs.git-tag-version }} | sed -n 's/v\([0-9]*\.[0-9]*\.[0-9]\)/\1/p' )
-          echo "RELEASE_FILE=StarrySky-${VERSION}_bin.zip" >> $GITHUB_ENV
+          echo "RELEASE_FILE=StarrySky-${VERSION}.zip" >> $GITHUB_ENV
 
       # Packaging
       - name: Packaging
         run: |
-          zip -r ${{ env.RELEASE_FILE }} ./StarrySky.vsix ./publishManifest.json
+          zip -r ${{ env.RELEASE_FILE }} ./StarrySky.vsix
 
       # Upload release Assets
       # https://github.com/AButler/upload-release-assets
@@ -44,3 +44,12 @@ jobs:
           files:  ${{ env.RELEASE_FILE }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           release-tag: ${{ inputs.git-tag-version }}
+
+      # Publish to Visual Studio Marketplace
+      # https://github.com/cezarypiatek/VsixPublisherAction
+      - name: Publish to Visual Studio Marketplace
+        uses: cezarypiatek/VsixPublisherAction@1.2
+        with:
+          extension-file: StarrySky.vsix
+          publish-manifest-file: publishManifest.json
+          personal-access-code: ${{ secrets.VSIX_MARKETPLACE_PAT }}

--- a/src/StarrySky/overview.md
+++ b/src/StarrySky/overview.md
@@ -1,0 +1,13 @@
+# StarrySky Theme
+
+StarrySky Theme for Visual Studio 2022/2026
+
+## Screenshots
+
+![C#](https://raw.githubusercontent.com/kgh02017/VSTheme-StarrySky/master/StarrySky-ss.png)
+
+## Installation
+
+1. Download the extension (vsix) file
+1. Install the extension to Visual Studio 2022 or Visual Studio 2026
+1. Select Tools > Theme > StarrySky

--- a/src/StarrySky/publishManifest.json
+++ b/src/StarrySky/publishManifest.json
@@ -2,5 +2,12 @@
     "publisher": "kgh02017",
     "identity": {
         "internalName": "starrysky"
-    }
+    },
+    "categories": [
+        "other"
+    ],
+    "tags": [
+        "Themes"
+    ],
+    "overview": "overview.md"
 }


### PR DESCRIPTION
This patch enables publishing to Visual Studio Marketplace in the release workflow. 
Since it is no longer necessary to include publishManifest.json in the release files, change 
the process so that it is not included in the release files.