### PR TITLE
ci:  introduce publish workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -48,6 +48,14 @@ jobs:
       git-tag-version: ${{ github.ref_name }}
     secrets: inherit
 
+  # Publish Job
+  publish:
+    needs: release-build
+    uses: ./.github/workflows/publish.yaml
+    with:
+      artifact-name: ${{ needs.release-build.outputs.artifact-name }}
+    secrets: inherit
+
   # Release Drafter Job
   update_release_draft:
     permissions:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,29 @@
+name: Publish Marketplace
+
+on:
+  workflow_call:
+    inputs:
+      artifact-name:
+        description: 'The name of artifacts to release'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    name: publish
+    runs-on: windows-latest
+    steps:
+      # Download artifact
+      # https://github.com/actions/download-artifact
+      - uses: actions/download-artifact@v5
+        with:
+          name: ${{ inputs.artifact-name }}
+
+      # Publish to Visual Studio Marketplace
+      # https://github.com/cezarypiatek/VsixPublisherAction
+      - name: Publish to Visual Studio Marketplace
+        uses: cezarypiatek/VsixPublisherAction@1.2
+        with:
+          extension-file: StarrySky.vsix
+          publish-manifest-file: publishManifest.json
+          personal-access-code: ${{ secrets.VSIX_MARKETPLACE_PAT }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,12 +44,3 @@ jobs:
           files:  ${{ env.RELEASE_FILE }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           release-tag: ${{ inputs.git-tag-version }}
-
-      # Publish to Visual Studio Marketplace
-      # https://github.com/cezarypiatek/VsixPublisherAction
-      - name: Publish to Visual Studio Marketplace
-        uses: cezarypiatek/VsixPublisherAction@1.2
-        with:
-          extension-file: StarrySky.vsix
-          publish-manifest-file: publishManifest.json
-          personal-access-code: ${{ secrets.VSIX_MARKETPLACE_PAT }}


### PR DESCRIPTION
VsixPublisherAction can only be used on a Windows runner, but the
 current release workflow runs on an Ubuntu runner, causing
VsixPublisherAction to fail.

This patch Introduces a new publish workflow that runs on a Windows runner and performs publishing to the Visual Studio Marketplace.